### PR TITLE
docs: fix simple typo, followign -> following

### DIFF
--- a/src/atomicvar.h
+++ b/src/atomicvar.h
@@ -21,7 +21,7 @@
  *
  * Never use return value from the macros, instead use the AtomicGetIncr()
  * if you need to get the current value and increment it atomically, like
- * in the followign example:
+ * in the following example:
  *
  *  long oldvalue;
  *  atomicGetIncr(myvar,oldvalue,1);

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -159,7 +159,7 @@ typedef struct clusterState {
                                    or zero if stil not received. */
     int mf_can_start;           /* If non-zero signal that the manual failover
                                    can start requesting masters vote. */
-    /* The followign fields are used by masters to take state on elections. */
+    /* The following fields are used by masters to take state on elections. */
     uint64_t lastVoteEpoch;     /* Epoch of the last vote granted. */
     int todo_before_sleep; /* Things to do in clusterBeforeSleep(). */
     /* Messages received and sent by type. */


### PR DESCRIPTION
There is a small typo in src/atomicvar.h, src/cluster.h.

Should read `following` rather than `followign`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md